### PR TITLE
6 rid of extra private keys and projects requirements

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -7,7 +7,6 @@ test ! -f "${SCRIPT_DIR}/bash_utils.sh" && echo "ERROR: Not found: ${SCIPT_DIR}/
 source "${SCRIPT_DIR}/bash_utils.sh"
 
 check_var SCRIPT_DIR
-check_var RUNDECK_GRAILS_URL
 check_var RUNDECK_ADMIN_USER
 check_var RUNDECK_ADMIN_PASSWORD Y
 
@@ -111,7 +110,7 @@ rm -rf "${RUNDECK_CONNECT_ERROR_FILE}"
 ## NOTE: it is not nice to use external interface from inside a container
 ##       but Rundeck provides many redirects to it, so it is more safe
 python3 "${SCRIPT_DIR}/import.py" \
-    --rundeck-url "${RUNDECK_GRAILS_URL}" \
+    --rundeck-url "http://127.0.0.1:4440" \
     --rundeck-user "${RUNDECK_ADMIN_USER}" \
     --rundeck-password "${RUNDECK_ADMIN_PASSWORD}"
 RETCODE="${?}"

--- a/bin/import.py
+++ b/bin/import.py
@@ -48,6 +48,7 @@ def main():
         raise FileNotFoundError(_args.rundeck_home)
 
     _rundeck = RundeckAPI(url=_args.rundeck_url, user=_args.rundeck_user, password=_args.rundeck_password)
+    _rundeck.web.verify = False
 
     import_secret_keys(_rundeck, _args.rundeck_home)
     import_passwords(_rundeck)
@@ -64,7 +65,8 @@ def import_secret_keys(rundeck, rundeck_home):
     _keys_dir = os.path.join(rundeck_home, "etc", "ssh-keys")
 
     if not os.path.isdir(_keys_dir):
-        raise FileNotFoundError(_keys_dir)
+        logging.warning(f"Skipping import SSH private keys: not found: [{_keys_dir}])")
+        return
 
     logging.info(f"Importing secret keys from [{_keys_dir}]")
 
@@ -113,7 +115,8 @@ def import_projects(rundeck, rundeck_home):
     _projects_dir = os.path.join(rundeck_home, "etc", "projects") 
 
     if not os.path.isdir(_projects_dir):
-        raise FileNotFoundError(_keys_dir)
+        logging.warning(f"Not importing projects: not found: [{_projects_dir}]")
+        return
 
     logging.info(f"Importing projects from [{_projects_dir}]")
 

--- a/bin/import.py
+++ b/bin/import.py
@@ -53,6 +53,7 @@ def main():
     import_secret_keys(_rundeck, _args.rundeck_home)
     import_passwords(_rundeck)
     import_projects(_rundeck, _args.rundeck_home)
+    logging.info("Importing done")
 
 def import_secret_keys(rundeck, rundeck_home):
     """
@@ -84,6 +85,8 @@ def import_secret_keys(rundeck, rundeck_home):
         with open(_file_path, mode='rb') as _f:
             rundeck.key_storage__upload(_rundeck_key_path, "private", _f.read())
 
+    logging.info("Secret keys imported")
+
 def import_passwords(rundeck):
     """
     Import passwords from environment variables
@@ -105,6 +108,8 @@ def import_passwords(rundeck):
         _rundeck_key_path = _k
         logging.info(f"Importing [{_k}] as [{_rundeck_key_path}]")
         rundeck.key_storage__upload(_rundeck_key_path, "password", _v.encode("utf-8"))
+
+    logging.info("Passwords imported")
     
 def import_projects(rundeck, rundeck_home):
     """
@@ -140,5 +145,7 @@ def import_projects(rundeck, rundeck_home):
             rundeck.scm__setup(_project, 'import', 'git-import', _scmc)
             rundeck.scm__enable(_project, 'import', 'git-import', True)
             rundeck.scm__perform_all_actions(_project, 'import', 'import-jobs')
+
+    logging.info("Projects imported")
     
 main()


### PR DESCRIPTION
- switched to use `localhost` *URL* instead of *external GRAILS_URL* inside container
- log *warning* instead of *raising an exception* in case of missing _projects_ and/or _private keys_
- force *SSL verification* to `False` (redirects need that)