### PR TITLE
8 make image compatible with okd security features

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,3 +29,8 @@ COPY --chown=rundeck:root bin /home/rundeck/docker-lib
 RUN chmod 755 /home/rundeck/docker-lib/*.sh
 
 ENTRYPOINT [ "/bin/bash", "/home/rundeck/docker-lib/entrypoint.sh" ]
+
+# Regardless we are using base image WORKDIR
+# some OKD security features wands us to specify the same value here directly
+# and this instruction have to be last
+WORKDIR /home/rundeck

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,15 @@ RUN apt-get --assume-yes update && \
     apt-get --assume-yes clean && \
     rm -rf /var/cache/apt/*
 
-USER rundeck
 # upgrade Python routines and install Python kubernetes client
-RUN python3 -m pip install --user --upgrade pip && \
-    python3 -m pip install --user --upgrade setuptools wheel && \
-    python3 -m pip install --user --upgrade kubernetes 'oc-cdtapi>=3.12.0'
+# NOTE: it is necessary to do this ad system level
+# since OKD breaks user-localized installation 
+# due to its ows security features paranoia
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install --upgrade setuptools wheel && \
+    python3 -m pip install --upgrade kubernetes 'oc-cdtapi>=3.12.0'
 
+USER rundeck
 # install K8S plugins
 # install Vault plugin
 ### NOTE: The exact download URL is unpreditable on GitHub
@@ -28,6 +31,13 @@ RUN cd /home/rundeck/libext && \
 COPY --chown=rundeck:root bin /home/rundeck/docker-lib
 RUN chmod 755 /home/rundeck/docker-lib/*.sh
 
+# it is necessary to make all items in /home/rundeck world-readable and writable
+# since OKD changing digital UID for the container user to unpredictable value
+# even if it is not root
+RUN find /home/rundeck -exec chown rundeck:root \{\} \; -exec chmod a+rw \{\} \; && \
+    find /home/rundeck -type d -exec chmod a+x \{\} \;
+
+# redefine base image entrypoint to ours
 ENTRYPOINT [ "/bin/bash", "/home/rundeck/docker-lib/entrypoint.sh" ]
 
 # Regardless we are using base image WORKDIR

--- a/bin/import.py
+++ b/bin/import.py
@@ -40,7 +40,6 @@ def main():
             _display_value = '*'*len(_v)
     
         logging.info(f"{_k.upper()}:\t[{_display_value}]")
-        os.environ[_k.upper()] = _v if isinstance(_v, str) else str(_v)
     
     _args.rundeck_home = os.path.abspath(_args.rundeck_home)
 


### PR DESCRIPTION
Fixes for *OKD* "security-features":
- *import.py* : rid of double-import *RUNDECK_PASSWORD*
- *Dockerfile*:  Fixes for *OKD* "security-features" to get rid of loosing read permissions for user-scope *home* objects
-- *python* module installation moved to system-wide scope
-- added *CHMOD* and *CHOWN* to force applying world read-write permissions for all */home/rundeck* files and folders
-- appended *WORKDIR* instruction